### PR TITLE
findFirstResource and BugoutClientApiError

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bugout/bugout-js",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "description": "JavaScript client library for Bugout API",
     "main": "lib/app.js",
     "types": "lib/app.d.ts",

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,7 @@ import FormData from "form-data"
 import * as BugoutTypes from "./types"
 import { bugoutBroodUrl, bugoutSpiredUrl, bugoutFilesUrl } from "./constants"
 
-export class BugoutClientApiError extends Error {
+export class BugoutResponseError extends Error {
     private statusCode: number
     constructor(name: string, statusCode: number, message?: string) {
         super(message)
@@ -374,7 +374,7 @@ export default class BugoutClient {
     async findFirstResource(token: string, params?: any): Promise<BugoutTypes.BugoutResource> {
         const list = await this.listResources(token, params)
         if (list.resources.length == 0) {
-            throw new BugoutClientApiError(
+            throw new BugoutResponseError(
                 "No resources found",
                 404,
                 "Predicate found no resources"


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

added `findFirstResource` function that will `listResources` + `getResource` and throw if no resources found 

added `BugoutClientApiError` class that allows to return meaningful errors to the consumer

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
